### PR TITLE
Fixing a typo (-react-commons)

### DIFF
--- a/app/js/api/__tests__/test-listing-data.js
+++ b/app/js/api/__tests__/test-listing-data.js
@@ -58,7 +58,7 @@ var apiListing = [
             {
                 "id": 1,
                 "contact_type": {
-                    "name": "Civillian"
+                    "name": "Civilian"
                 },
                 "secure_phone": null,
                 "unsecure_phone": "321-123-7894",


### PR DESCRIPTION
ozp-center, ozp-backend, and ozp-react-commons all have this typo and a PR to match. (Civilian vs Civillian)

@mannyrivera2010 @lsemesky @mleeBoeing @J-Fid 

