### PR TITLE
Change the disclaimer for categories

### DIFF
--- a/app/js/constants/messages.js
+++ b/app/js/constants/messages.js
@@ -106,7 +106,7 @@ var listingMessages = {
     'help.owners': 'At least one owner is required.',
     'help.tags': 'May contain letters, numbers or symbols and must be 30 characters long or less.',
     'help.launchUrl': 'Must be a valid URL.',
-    'help.categories': 'At least one is required.',
+    'help.categories': 'At least one, no more than three, required.',
     'help.contacts.name': 'May contain letters, numbers or symbols and must be 100 characters long or less.',
     'help.contacts.organization': 'May contain letters, numbers or symbols and must be 100 characters long or less.',
     'help.contacts.email': 'Must be a valid email address and 100 characters long or less.',


### PR DESCRIPTION
Change the disclaimer text for categories in Create Listing page to say "At least one, no more than three, required".