### PR TITLE
Profile title

### DIFF
--- a/app/js/components/Modal.jsx
+++ b/app/js/components/Modal.jsx
@@ -75,14 +75,14 @@ var BootstrapModal = React.createClass({
                 <div className={dialogClasses}>
                     <div className="modal-content">
                         {
-                            this.props.title && (
+                            this.props.modaltitle && (
                                 <div className="modal-header">
                                     <button type="button" className="close"
                                             onClick={ this.handleCancel }>
                                         <span aria-hidden="true"><i className="icon-cross-16"></i></span>
                                         <span className="sr-only">Close</span>
                                     </button>
-                                    <h4 className="modal-title">{this.props.title}</h4>
+                                    <h4 className="modal-title">{this.props.modaltitle}</h4>
                                 </div>
                             )
                         }

--- a/app/js/components/contacts/ContactsWindow.jsx
+++ b/app/js/components/contacts/ContactsWindow.jsx
@@ -100,7 +100,7 @@ var ContactsWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal title="Contact" ref="modal"
+            <Modal ref="modal"
                     className="contacts-window" size="large"
                     onCancel={this.close}>
                 <ContactInfo/>

--- a/app/js/components/contacts/ContactsWindow.jsx
+++ b/app/js/components/contacts/ContactsWindow.jsx
@@ -100,7 +100,7 @@ var ContactsWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal ref="modal"
+            <Modal modaltitle="Contact" ref="modal"
                     className="contacts-window" size="large"
                     onCancel={this.close}>
                 <ContactInfo/>

--- a/app/js/components/error/ErrorWindow.jsx
+++ b/app/js/components/error/ErrorWindow.jsx
@@ -14,7 +14,7 @@ var ErrorWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal title="Error" ref="modal"
+            <Modal ref="modal"
             className="error-window"
             onCancel={this.close}>
                 <div>{this.props.errorMessage}</div>

--- a/app/js/components/error/ErrorWindow.jsx
+++ b/app/js/components/error/ErrorWindow.jsx
@@ -14,7 +14,7 @@ var ErrorWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal ref="modal"
+            <Modal modaltitle="Error" ref="modal"
             className="error-window"
             onCancel={this.close}>
                 <div>{this.props.errorMessage}</div>

--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -176,7 +176,7 @@ var ProfileWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal title="Profile" ref="modal"
+            <Modal ref="modal"
                     className="profile-window"
                     onCancel={this.close}>
                 <ProfileInfo profileId={this.props.profileId}

--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -176,7 +176,7 @@ var ProfileWindow = React.createClass({
 
     render: function() {
         return (
-            <Modal ref="modal"
+            <Modal modaltitle="Profile" ref="modal"
                     className="profile-window"
                     onCancel={this.close}>
                 <ProfileInfo profileId={this.props.profileId}


### PR DESCRIPTION
The 'title' prop in Modal was inadvertently being used as the 'title' attribute as well.  This PR changes the prop to `modaltitle` instead to remove the unnecessary mouseover title.

@rkenyon1969 @mleeBoeing @lsemesky 