### PR TITLE
Notification folder share refactor

### DIFF
--- a/app/js/actions/ProfileActions.js
+++ b/app/js/actions/ProfileActions.js
@@ -53,7 +53,19 @@ var ProfileActions = createActions({
     updateProfileFlags(data) {
        ProfileApi.updateProfileFlags(data)
            .done(ProfileActions.updateProfileFlagsCompleted);
-    } 
+    },
+
+    addBookmarkFolder(bookmarkFolder, notification){
+        ProfileApi.addBookmarkFolder(bookmarkFolder)
+        .success(function() {
+            if(notification)
+                ProfileActions.dismissNotification(notification);
+            ProfileActions.addBookMarkFolderCompleted(bookmarkFolder);
+        })
+        .fail(function () {
+            ProfileActions.addBookmarkFolderFailed(bookmarkFolder);
+        })
+    }
 });
 
 _.assign(ProfileActions, Reflux.createActions([

--- a/app/js/actions/ProfileActions.js
+++ b/app/js/actions/ProfileActions.js
@@ -59,7 +59,7 @@ var ProfileActions = createActions({
         ProfileApi.addBookmarkFolder(notification)
         .success(function() {
             ProfileActions.dismissNotification(notification);
-            ProfileActions.addBookMarkFolderCompleted(notification);
+            ProfileActions.addBookmarkFolderCompleted(notification);
         })
         .fail(function () {
             ProfileActions.addBookmarkFolderFailed(notification);

--- a/app/js/actions/ProfileActions.js
+++ b/app/js/actions/ProfileActions.js
@@ -55,15 +55,14 @@ var ProfileActions = createActions({
            .done(ProfileActions.updateProfileFlagsCompleted);
     },
 
-    addBookmarkFolder(bookmarkFolder, notification){
-        ProfileApi.addBookmarkFolder(bookmarkFolder)
+    addBookmarkFolder(notification){
+        ProfileApi.addBookmarkFolder(notification)
         .success(function() {
-            if(notification)
-                ProfileActions.dismissNotification(notification);
-            ProfileActions.addBookMarkFolderCompleted(bookmarkFolder);
+            ProfileActions.dismissNotification(notification);
+            ProfileActions.addBookMarkFolderCompleted(notification);
         })
         .fail(function () {
-            ProfileActions.addBookmarkFolderFailed(bookmarkFolder);
+            ProfileActions.addBookmarkFolderFailed(notification);
         })
     }
 });

--- a/app/js/api/Profile.js
+++ b/app/js/api/Profile.js
@@ -96,10 +96,16 @@ var ProfileApi = {
     },
 
     addBookmarkFolder: function (bookmarkFolder) {
-        
-    }
-
-    
+        return $.ajax({
+            type: 'POST',
+            dataType: 'json',
+            contentType: 'application/json',
+            url: API_URL + '/api/self/library/import_bookmarks/',
+            data: JSON.stringify({
+            "bookmark_notification_id": this.props.notification.id
+            })
+        });
+    }   
 };
 
 module.exports = ProfileApi;

--- a/app/js/api/Profile.js
+++ b/app/js/api/Profile.js
@@ -96,6 +96,7 @@ var ProfileApi = {
     },
 
     addBookmarkFolder: function (notification) {
+        console.log(notification)
         return $.ajax({
             type: 'POST',
             dataType: 'json',

--- a/app/js/api/Profile.js
+++ b/app/js/api/Profile.js
@@ -96,7 +96,6 @@ var ProfileApi = {
     },
 
     addBookmarkFolder: function (notification) {
-        console.log(notification)
         return $.ajax({
             type: 'POST',
             dataType: 'json',

--- a/app/js/api/Profile.js
+++ b/app/js/api/Profile.js
@@ -93,7 +93,13 @@ var ProfileApi = {
             contentType: 'application/json',
             data: JSON.stringify(humps.decamelizeKeys(notification))
         })
+    },
+
+    addBookmarkFolder: function (bookmarkFolder) {
+        
     }
+
+    
 };
 
 module.exports = ProfileApi;

--- a/app/js/api/Profile.js
+++ b/app/js/api/Profile.js
@@ -95,14 +95,14 @@ var ProfileApi = {
         })
     },
 
-    addBookmarkFolder: function (bookmarkFolder) {
+    addBookmarkFolder: function (notification) {
         return $.ajax({
             type: 'POST',
             dataType: 'json',
             contentType: 'application/json',
             url: API_URL + '/api/self/library/import_bookmarks/',
             data: JSON.stringify({
-            "bookmark_notification_id": this.props.notification.id
+            "bookmark_notification_id": notification.notificationId
             })
         });
     }   

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -35,4 +35,4 @@ NotificationContent = React.createClass({
     }
 });
 
-model.exports= NotificationContent;
+module.exports= NotificationContent;

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -9,7 +9,6 @@ var NotificationContent = React.createClass({
     propTypes: {notification: React.PropTypes.object.isRequired},
     render: function() {
         var notification = this.props.notification;
-        console.log(notification);
         if (!notification)
             return (<div></div>);
         var createNotificationText = function() {
@@ -26,7 +25,7 @@ var NotificationContent = React.createClass({
                     {notification.message && <p className="message small">Message: {notification.message}</p>}
                     <div>
                         <button className="btn btn-success btn-sm" onClick={() => {
-                            SelfActions.addBookmarkFolder(notification.peer, notification);
+                            SelfActions.addBookmarkFolder(notification);
                         }}>Add folder {notification.peer.folderName}</button>
                     </div>
                     </div>

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -1,0 +1,38 @@
+'use strict';
+var React = require('react');
+var Reflux = require('reflux');
+var SelfActions = require('../../actions/ProfileActions.js');
+var marked = require('marked');
+var renderer = new marked.Renderer();
+
+NotificationContent = React.createClass({
+    propTypes: {notification: React.propTypes.object.isRequired},
+    render: function() {
+        var notification = this.props.notification;
+        if (!notification)
+            return <div></div>
+        var createNotificationText = function() {
+            return {__html: marked(notification.message, { renderer: renderer })};
+          };
+        return 
+        <div>
+            { notification.notificationType !== "peer_bookmark" &&
+            <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
+        }
+        { notification.notificationType === "peer_bookmark" &&
+            <div>
+            <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
+            {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
+            {notification.message && <p className="message small">Message: {notification.message}</p>}
+            <div>
+                <button className="btn btn-success btn-sm" onClick={() => {
+                    SelfActions.addBookmarkFolder(notification.peer, notification);
+                }}>Add folder {notification.peer.folder_name}</button>
+            </div>
+            </div>
+        }
+        </div>
+    }
+});
+
+model.exports= NotificationContent;

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -6,7 +6,7 @@ var marked = require('marked');
 var renderer = new marked.Renderer();
 
 NotificationContent = React.createClass({
-    propTypes: {notification: React.propTypes.object.isRequired},
+    propTypes: {notification: React.PropTypes.object.isRequired},
     render: function() {
         var notification = this.props.notification;
         if (!notification)

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -10,28 +10,29 @@ var NotificationContent = React.createClass({
     render: function() {
         var notification = this.props.notification;
         if (!notification)
-            return <div></div>
+            return (<div></div>);
         var createNotificationText = function() {
             return {__html: marked(notification.message, { renderer: renderer })};
           };
-        return 
-        <div>
-            { notification.notificationType !== "peer_bookmark" &&
-            <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
-        }
-        { notification.notificationType === "peer_bookmark" &&
+        return (
             <div>
-            <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
-            {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
-            {notification.message && <p className="message small">Message: {notification.message}</p>}
-            <div>
-                <button className="btn btn-success btn-sm" onClick={() => {
-                    SelfActions.addBookmarkFolder(notification.peer, notification);
-                }}>Add folder {notification.peer.folder_name}</button>
+                { notification.notificationType !== "peer_bookmark" &&
+                <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
+            }
+            { notification.notificationType === "peer_bookmark" &&
+                <div>
+                <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
+                {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
+                {notification.message && <p className="message small">Message: {notification.message}</p>}
+                <div>
+                    <button className="btn btn-success btn-sm" onClick={() => {
+                        SelfActions.addBookmarkFolder(notification.peer, notification);
+                    }}>Add folder {notification.peer.folder_name}</button>
+                </div>
+                </div>
+            }
             </div>
-            </div>
-        }
-        </div>
+        )
     }
 });
 

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -5,7 +5,7 @@ var SelfActions = require('../../actions/ProfileActions.js');
 var marked = require('marked');
 var renderer = new marked.Renderer();
 
-NotificationContent = React.createClass({
+var NotificationContent = React.createClass({
     propTypes: {notification: React.PropTypes.object.isRequired},
     render: function() {
         var notification = this.props.notification;

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -9,6 +9,7 @@ var NotificationContent = React.createClass({
     propTypes: {notification: React.PropTypes.object.isRequired},
     render: function() {
         var notification = this.props.notification;
+        console.log(notification);
         if (!notification)
             return (<div></div>);
         var createNotificationText = function() {
@@ -22,12 +23,12 @@ var NotificationContent = React.createClass({
             { notification.notificationType === "peer_bookmark" &&
                 <div>
                 <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
-                {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
+                {notification.peer.folderName && <p className="message small">Folder Name: {notification.peer.folderName}</p>}
                 {notification.message && <p className="message small">Message: {notification.message}</p>}
                 <div>
                     <button className="btn btn-success btn-sm" onClick={() => {
                         SelfActions.addBookmarkFolder(notification.peer, notification);
-                    }}>Add folder {notification.peer.folder_name}</button>
+                    }}>Add folder {notification.peer.folderName}</button>
                 </div>
                 </div>
             }

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -19,19 +19,18 @@ var NotificationContent = React.createClass({
             <div>
                 { notification.notificationType !== "peer_bookmark" &&
                 <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
-            }
-            { notification.notificationType === "peer_bookmark" &&
-                <div>
-                <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
-                {notification.peer.folderName && <p className="message small">Folder Name: {notification.peer.folderName}</p>}
-                {notification.message && <p className="message small">Message: {notification.message}</p>}
-                <div>
-                    <button className="btn btn-success btn-sm" onClick={() => {
-                        SelfActions.addBookmarkFolder(notification.peer, notification);
-                    }}>Add folder {notification.peer.folderName}</button>
-                </div>
-                </div>
-            }
+                }
+                { notification.notificationType === "peer_bookmark" &&
+                    <div>
+                    <p className="message small">{notification.author.user.username} has shared {notification.peer.folderName?'the folder '+notification.peer.folderName :'a folder'} with you.</p>
+                    {notification.message && <p className="message small">Message: {notification.message}</p>}
+                    <div>
+                        <button className="btn btn-success btn-sm" onClick={() => {
+                            SelfActions.addBookmarkFolder(notification.peer, notification);
+                        }}>Add folder {notification.peer.folderName}</button>
+                    </div>
+                    </div>
+                }
             </div>
         )
     }

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -168,9 +168,8 @@ var NotificationSideBar = React.createClass({
             var formattedDate = months[date.getMonth()] + ' ' + date.getDate() + ', ' +  date.getFullYear();
             return (
                 <li role="presentation" alt={`Notification ${i + 1} from ${(n.listing) ? n.listing.title : 'AppsMall'}`} tabIndex={i} 
-                onClick={(event) => {this.props.handleNotificationChange(event, i)}}
-                className={i===this.props.activeNotificationIndex?'notification-selected':''}>
-                <a href="#" onClick={(e) => {e.preventDefault()}}>
+                onClick={(event) => {this.props.handleNotificationChange(event, i)}}>
+                <a href="#" onClick={(e) => {e.preventDefault()}} className={i===this.props.activeNotificationIndex?'notification-selected':''}>
                     {(n.listing) ? n.listing.title : 'AppsMall'} <small>{formattedDate}</small>
                 </a>
                 </li>

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -115,8 +115,9 @@ var Notification = React.createClass({
                   }
                   { notification.notificationType === "peer_bookmark" &&
                     <div>
-                      <p className="message small">{notification.author.user.username} has shared the folder <b>{notification.peer.folderName}</b> with you.</p>
-                      <p className="message small">{notification.message}</p>
+                      <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
+                      {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
+                      {notification.message && <p className="message small">Message: {notification.message}</p>}
                       <div>
                         <button className="btn btn-success btn-sm" onClick={() => {
                             $.ajax({
@@ -130,7 +131,7 @@ var Notification = React.createClass({
                             }).success(() => {
                               this.onDismiss(notification);
                             });
-                          }}>Add {notification.peer.folderName}</button>
+                          }}>Add folder {notification.peer.folder_name}</button>
                       </div>
                     </div>
                   }

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -69,13 +69,9 @@ var NotificationInfo = React.createClass({
     render: function() {
         return (
             <div className="row">
-            <div className="col-xs-4">
-            <ul className="nav nav-pills nav-inverse nav-stacked">
-                <NotificationSideBar activeNotificationIndex={this.state.activeNotificationIndex}
-                notificationList={this.state.notificationList} 
-                handleNotificationChange={this.handleNotificationChange}/>
-            </ul>
-            </div>
+            <NotificationSideBar activeNotificationIndex={this.state.activeNotificationIndex}
+            notificationList={this.state.notificationList} 
+            handleNotificationChange={this.handleNotificationChange}/>
             <div className="col-xs-8">
             { this.state.notificationList.length > 0 &&
                 <Notification notification={this.state.notificationList[this.state.activeNotificationIndex]} />
@@ -164,7 +160,8 @@ var NotificationSideBar = React.createClass({
         var notis = this.props.notificationList.slice(0);
         
         return ( 
-            <div>
+            <div className="col-xs-4">
+            <ul className="nav nav-pills nav-inverse nav-stacked">
             {notis.map((n, i) => {
             var date = new Date(n.createdDate);
             var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
@@ -178,6 +175,7 @@ var NotificationSideBar = React.createClass({
                 </li>
             );
             })}
+            </ul>
             </div>
         );
     }

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -9,6 +9,7 @@ var { Navigation } = require('react-router');
 
 var SelfStore = require('../../stores/SelfStore');
 var SelfActions = require('../../actions/ProfileActions.js');
+var NotificationContent = require ('./NotificationContent')
 var { API_URL } = require('../../OzoneConfig');
 
  var marked = require('marked');
@@ -110,31 +111,7 @@ var Notification = React.createClass({
                 <h4>{(notification.listing) ? notification.listing.title : 'AppsMall'} <small>{formattedDate}</small></h4>
                 <div>
     
-                  { notification.notificationType !== "peer_bookmark" &&
-                    <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
-                  }
-                  { notification.notificationType === "peer_bookmark" &&
-                    <div>
-                      <p className="message small">{notification.author.user.username} has shared a folder with you.</p>
-                      {notification.peer.folder_name && <p className="message small">Folder Name: {notification.peer.folder_name}</p>}
-                      {notification.message && <p className="message small">Message: {notification.message}</p>}
-                      <div>
-                        <button className="btn btn-success btn-sm" onClick={() => {
-                            $.ajax({
-                                type: 'POST',
-                                dataType: 'json',
-                                contentType: 'application/json',
-                                url: API_URL + '/api/self/library/import_bookmarks/',
-                                data: JSON.stringify({
-                                  "bookmark_notification_id": notification.id
-                                })
-                            }).success(() => {
-                              this.onDismiss(notification);
-                            });
-                          }}>Add folder {notification.peer.folder_name}</button>
-                      </div>
-                    </div>
-                  }
+                  <NotificationContent notification={notification} />
                   <br /><br />
                   <button className="btn btn-danger right" aria-label={`Remove notification from ${(notification.listing) ? notification.listing.title : 'AppsMall'}`} onClick={() => {
                       this.onDismiss(notification);

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -26,7 +26,7 @@ var NotificationsModal = React.createClass({
     
     render: function() { 
         return (
-            <Modal title="Notifications" ref="modal"
+            <Modal modaltitle="Notifications" ref="modal"
             className="notification-window"
              onHidden={this.props.onHidden} onCancel={this.close}>
                 <NotificationInfo />

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -18,8 +18,17 @@ var NotificationsModal = React.createClass({
     mixins: [Reflux.ListenerMixin],
     getInitialState: function() {
         return {
-            notificationList: []
+            notificationList: [],
+            backRoute: (History.length > 1) ?
+                    this.goBack : 
+                    this.getActiveRoutePath()
         };
+    },
+    propTypes: {
+        backRoute: React.PropTypes.oneOfType([
+            React.PropTypes.string.isRequired,
+            React.PropTypes.func.isRequired
+        ])
     },
     componentWillMount: function() {
         this.listenTo(SelfActions.fetchNotificationsCompleted, response => {
@@ -149,7 +158,9 @@ var Notification = React.createClass({
             </div>
           );
     },
-    onDismiss: function(){},
+    onDismiss: function(notification){
+        SelfActions.dismissNotification(notification);
+    }
 });
 
 var NotificationSideBar = React.createClass({

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -127,7 +127,7 @@ var Notification = React.createClass({
                                 data: JSON.stringify({
                                   "bookmark_notification_id": notification.id
                                 })
-                            }).done(() => {
+                            }).success(() => {
                               this.onDismiss(notification);
                             });
                           }}>Add {notification.peer.folderName}</button>

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -1,0 +1,184 @@
+'use strict';
+
+var React = require('react');
+var Reflux = require('reflux');
+
+var Modal = require('../Modal.jsx');
+
+var { Navigation } = require('react-router');
+
+var SelfStore = require('../../stores/SelfStore');
+var SelfActions = require('../../actions/ProfileActions.js');
+var { API_URL } = require('../../OzoneConfig');
+
+ var marked = require('marked');
+ var renderer = new marked.Renderer();
+
+var NotificationsModal = React.createClass({
+    mixins: [Reflux.ListenerMixin],
+    getInitialState: function() {
+        return {
+            notificationList: []
+        };
+    },
+    componentWillMount: function() {
+        this.listenTo(SelfActions.fetchNotificationsCompleted, response => {
+            this.setState({
+                notificationList: response._response
+            });
+        });
+        this.listenTo(SelfActions.dismissNotificationCompleted, () => {
+            SelfActions.fetchNotifications();
+        })
+
+        SelfActions.fetchNotifications();
+    },
+    render: function() { 
+        console.log(this.state.notificationList)
+        return (
+            <Modal title="Notifications" ref="modal"
+            className="notification-window"
+            onCancel={this.close}>
+                <NotificationInfo notificationList={this.state.notificationList} />
+            </Modal>
+        );
+    },
+    close: function() {
+        var backRoute = this.props.backRoute;
+
+        if (typeof backRoute === 'function') {
+            backRoute();
+        }
+        else {
+            this.transitionTo(this.props.backRoute);
+        }
+    }
+   
+});
+
+var NotificationInfo = React.createClass({
+    propTypes: {
+        notificationList: React.PropTypes.array.isRequired,
+    },
+    getInitialState: function() {
+        return {
+            activeNotificationIndex: 0       
+        }
+    },
+    render: function() {
+        return (
+            <div className="row">
+            <div className="col-xs-4">
+            <ul className="nav nav-pills nav-inverse nav-stacked">
+                <NotificationSideBar activeNotificationIndex={this.state.activeNotificationIndex}
+                notificationList={this.props.notificationList} 
+                handleNotificationChange={this.handleNotificationChange}/>
+            </ul>
+            </div>
+            <div className="col-xs-8">
+            { this.props.notificationList.length > 0 &&
+                <Notification notification={this.props.notificationList[this.state.activeNotificationIndex]} />
+            }
+
+            { !this.props.notificationList.length &&
+                <span>No notifications</span>
+            }
+            </div>
+        </div>
+      );
+    },
+    handleNotificationChange: function(event, index) {
+        this.setState({activeNotificationIndex: index})
+    }
+});
+
+var Notification = React.createClass({
+    propTypes: {
+        notification: React.PropTypes.object
+    },
+    
+    render: function() { 
+        var notification = this.props.notification;
+        console.log(this.props.notification)
+        if(!this.props.notification)
+            return <div></div>
+        var createNotificationText = function() {
+            return {__html: marked(notification.message, { renderer: renderer })};
+          };
+          var date = new Date(notification.createdDate);
+          var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+          var formattedDate = months[date.getMonth()] + ' ' + date.getDate() + ', ' +  date.getFullYear();
+          return (
+            <div>
+              <div className="row" tabIndex={0}>
+                <h4>{(notification.listing) ? notification.listing.title : 'AppsMall'} <small>{formattedDate}</small></h4>
+                <div>
+    
+                  { notification.notificationType !== "peer_bookmark" &&
+                    <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
+                  }
+                  { notification.notificationType === "peer_bookmark" &&
+                    <div>
+                      <p className="message small">{notification.author.user.username} has shared a the folder <b>{notification.peer.folderName}</b> with you.</p>
+                      <p className="message small">{notification.message}</p>
+                      <div>
+                        <button className="btn btn-success btn-sm" onClick={() => {
+                            $.ajax({
+                                type: 'POST',
+                                dataType: 'json',
+                                contentType: 'application/json',
+                                url: API_URL + '/api/self/library/import_bookmarks/',
+                                data: JSON.stringify({
+                                  "bookmark_notification_id": notification.id
+                                })
+                            }).done(() => {
+                              this.onDismiss(notification);
+                            });
+                          }}>Add {notification.peer.folderName}</button>
+                      </div>
+                    </div>
+                  }
+                  <br /><br />
+                  <button className="btn btn-danger right" aria-label={`Remove notification from ${(notification.listing) ? notification.listing.title : 'AppsMall'}`} onClick={() => {
+                      this.onDismiss(notification);
+                    }}>
+                    Remove Notification
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+    },
+    onDismiss: function(){},
+});
+
+var NotificationSideBar = React.createClass({
+    propTypes: {
+        notificationList: React.PropTypes.array.isRequired,
+        activeNotificationIndex: React.PropTypes.number.isRequired,
+        handleNotificationChange: React.PropTypes.func.isRequired
+    },
+    render: function() {
+        var notis = this.props.notificationList.slice(0);
+        
+        return ( 
+            <div>
+            {notis.map((n, i) => {
+            var date = new Date(n.createdDate);
+            var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+            var formattedDate = months[date.getMonth()] + ' ' + date.getDate() + ', ' +  date.getFullYear();
+            return (
+                <li role="presentation" alt={`Notification ${i + 1} from ${(n.listing) ? n.listing.title : 'AppsMall'}`} tabIndex={i} 
+                onClick={(event) => {this.props.handleNotificationChange(event, i)}}>
+                <a href="#" onClick={(e) => {e.preventDefault()}}>
+                    {(n.listing) ? n.listing.title : 'AppsMall'} <small>{formattedDate}</small>
+                </a>
+                </li>
+            );
+            })}
+            </div>
+        );
+    }
+})
+
+module.exports = NotificationsModal;

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -115,7 +115,7 @@ var Notification = React.createClass({
                   }
                   { notification.notificationType === "peer_bookmark" &&
                     <div>
-                      <p className="message small">{notification.author.user.username} has shared a the folder <b>{notification.peer.folderName}</b> with you.</p>
+                      <p className="message small">{notification.author.user.username} has shared the folder <b>{notification.peer.folderName}</b> with you.</p>
                       <p className="message small">{notification.message}</p>
                       <div>
                         <button className="btn btn-success btn-sm" onClick={() => {
@@ -168,7 +168,8 @@ var NotificationSideBar = React.createClass({
             var formattedDate = months[date.getMonth()] + ' ' + date.getDate() + ', ' +  date.getFullYear();
             return (
                 <li role="presentation" alt={`Notification ${i + 1} from ${(n.listing) ? n.listing.title : 'AppsMall'}`} tabIndex={i} 
-                onClick={(event) => {this.props.handleNotificationChange(event, i)}}>
+                onClick={(event) => {this.props.handleNotificationChange(event, i)}}
+                className={i===this.props.activeNotificationIndex?'notification-selected':''}>
                 <a href="#" onClick={(e) => {e.preventDefault()}}>
                     {(n.listing) ? n.listing.title : 'AppsMall'} <small>{formattedDate}</small>
                 </a>

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -9,7 +9,7 @@ var { Navigation } = require('react-router');
 
 var SelfStore = require('../../stores/SelfStore');
 var SelfActions = require('../../actions/ProfileActions.js');
-var NotificationContent = require ('./NotificationContent.jsx')
+var NotificationContent = require ('./NotificationContent.jsx');
 var { API_URL } = require('../../OzoneConfig');
 
  var marked = require('marked');

--- a/app/js/components/notification/NotificationsModal.jsx
+++ b/app/js/components/notification/NotificationsModal.jsx
@@ -9,7 +9,7 @@ var { Navigation } = require('react-router');
 
 var SelfStore = require('../../stores/SelfStore');
 var SelfActions = require('../../actions/ProfileActions.js');
-var NotificationContent = require ('./NotificationContent')
+var NotificationContent = require ('./NotificationContent.jsx')
 var { API_URL } = require('../../OzoneConfig');
 
  var marked = require('marked');

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -7,7 +7,7 @@ var Time = require('../Time.jsx');
 var $ = require('jquery');
 var { API_URL } = require('../../OzoneConfig');
 var CenterModalLink = require('../CenterModalLink.jsx');
-var NotificationContent = require('./NotificationContent.jsx')
+var NotificationContent = require('./NotificationContent.jsx');
 
 var SelfActions = require('../../actions/ProfileActions.js');
 var marked = require('marked');

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -7,7 +7,7 @@ var Time = require('../Time.jsx');
 var $ = require('jquery');
 var { API_URL } = require('../../OzoneConfig');
 var CenterModalLink = require('../CenterModalLink.jsx');
-var NotificationContent = require('./NotificationContent')
+var NotificationContent = require('./NotificationContent.jsx')
 
 var SelfActions = require('../../actions/ProfileActions.js');
 var marked = require('marked');

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -89,7 +89,7 @@ var UserNotification = React.createClass({
                 }
                 { this.props.notification.notificationType === "PEER.BOOKMARK" &&
                   <div>
-                    <p className="message small">{this.props.notification.author.user.username} has shared a the folder <b>{this.props.notification.peer.folderName}</b> with you.</p>
+                    <p className="message small">{this.props.notification.author.user.username} has shared the folder <b>{this.props.notification.peer.folderName}</b> with you.</p>
                     <p className="message small">{this.props.notification.message}</p>
                     <div>
                       <button className="btn btn-default btn-sm" onClick={this.onDismiss}>Ignore</button>

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -76,7 +76,8 @@ var UserNotification = React.createClass({
           listingLink = 'AppsMall';
 
         return (
-            <li className={(this.props.notification.readStatus === false ? 'unread ': '') + "UserNotification clearfix"} onClick={() => {SelfActions.readNotification(this.props.notification)}}>
+            <li className={(this.props.notification.readStatus === false ? 'unread ': '') + "UserNotification clearfix"} 
+            onClick={() => { this.props.openDropdown(); SelfActions.readNotification(this.props.notification)}}>
                 <button type="button" className="close pull-right" onClick={this.onDismiss}><i className="icon-cross-16"></i></button>
                 <h5 className="created-by">
                   {listingLink}

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -84,10 +84,10 @@ var UserNotification = React.createClass({
                     <_Date date={createdDate} />
                     <Time date={createdDate} />
                 </div>
-                { !(this.props.notification.notificationType === "PEER.BOOKMARK") &&
+                { !(this.props.notification.notificationType === "peer_bookmark") &&
                   <p className="message small" dangerouslySetInnerHTML={createNotificationText()}></p>
                 }
-                { this.props.notification.notificationType === "PEER.BOOKMARK" &&
+                { this.props.notification.notificationType === "peer_bookmark" &&
                   <div>
                     <p className="message small">{this.props.notification.author.user.username} has shared the folder <b>{this.props.notification.peer.folderName}</b> with you.</p>
                     <p className="message small">{this.props.notification.message}</p>

--- a/app/js/components/notification/UserNotification.jsx
+++ b/app/js/components/notification/UserNotification.jsx
@@ -7,6 +7,7 @@ var Time = require('../Time.jsx');
 var $ = require('jquery');
 var { API_URL } = require('../../OzoneConfig');
 var CenterModalLink = require('../CenterModalLink.jsx');
+var NotificationContent = require('./NotificationContent')
 
 var SelfActions = require('../../actions/ProfileActions.js');
 var marked = require('marked');
@@ -84,33 +85,7 @@ var UserNotification = React.createClass({
                     <_Date date={createdDate} />
                     <Time date={createdDate} />
                 </div>
-                { !(this.props.notification.notificationType === "peer_bookmark") &&
-                  <p className="message small" dangerouslySetInnerHTML={createNotificationText()}></p>
-                }
-                { this.props.notification.notificationType === "peer_bookmark" &&
-                  <div>
-                    <p className="message small">{this.props.notification.author.user.username} has shared the folder <b>{this.props.notification.peer.folderName}</b> with you.</p>
-                    <p className="message small">{this.props.notification.message}</p>
-                    <div>
-                      <button className="btn btn-default btn-sm" onClick={this.onDismiss}>Ignore</button>
-                      <button className="btn btn-success btn-sm" onClick={() => {
-                          $.ajax({
-                              type: 'POST',
-                              dataType: 'json',
-                              contentType: 'application/json',
-                              url: API_URL + '/api/self/library/import_bookmarks/',
-                              data: JSON.stringify({
-                                "bookmark_notification_id": this.props.notification.id
-                              })
-                          }).done(() => {
-                            this.props.openDropdown();
-                            SelfActions.dismissNotification(this.props.notification);
-                            this.props.updateHud();
-                          });
-                        }}>Add {this.props.notification.peer.folderName}</button>
-                    </div>
-                  </div>
-                }
+                <NotificationContent notification={this.props.notification} />
             </li>
         );
     }

--- a/app/styles/_bootstrap.scss
+++ b/app/styles/_bootstrap.scss
@@ -1,0 +1,50 @@
+// Core variables and mixins
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/mixins";
+
+// Reset and dependencies
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/print";
+// @import "bootstrap/glyphicons";
+
+// Core CSS
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/type";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/code";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/grid";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/tables";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/forms";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/buttons";
+
+// Components
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/dropdowns";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/navs";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/navbar";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/pagination";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/pager";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/labels";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/badges";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/jumbotron";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/thumbnails";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/alerts";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/progress-bars";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/media";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/list-group";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/panels";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-embed";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/wells";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/close";
+
+// Components w/ JavaScript
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/modals";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/tooltip";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/popovers";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/carousel";
+
+// Utility classes
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/utilities";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -1,0 +1,3 @@
+.right {
+    float:right;
+}

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -4,4 +4,5 @@
 
 .notification-selected {
       border-left: 4px solid #009dd3 !important;
+      padding-left: 6px !important;
 }

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -3,5 +3,5 @@
 }
 
 .notification-selected {
-      border-left: 4px solid $dark-blue;
+      border-left: 4px solid #087299;
 }

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -2,21 +2,6 @@
     float:right;
 }
 
-.nav-pills > li {
-    float: left; }
-    .nav-pills > li > a {
-      border-radius: 0px;
-      color: #3b4246;
-      background-color: #eeeeef; }
-      .nav-pills > li > a:hover, .nav-pills > li > a:focus {
-        background-color: #eeeeef;
-        border-top: 4px solid #009dd3;
-        padding-top: 6px; }
-    .nav-pills > li + li {
-      margin-left: 2px; }
-    .nav-pills > li.active > a {
-      background-color: #2b3036; }
-      .nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus, .notification-selected {
-        color: #009dd3;
-        border-top: 4px solid #009dd3;
-        padding-top: 6px; }
+.notification-selected {
+      border-left: 4px solid $dark-blue;
+}

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -3,5 +3,5 @@
 }
 
 .notification-selected {
-      border-left: 4px solid #087299 !important;
+      border-left: 4px solid #009dd3 !important;
 }

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -16,7 +16,7 @@
       margin-left: 2px; }
     .nav-pills > li.active > a {
       background-color: #2b3036; }
-      .nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus, .nav-pills > li > .notification-selected {
+      .nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus, .notification-selected {
         color: #009dd3;
         border-top: 4px solid #009dd3;
         padding-top: 6px; }

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -3,5 +3,5 @@
 }
 
 .notification-selected {
-      border-left: 4px solid #087299;
+      border-left: 4px solid #087299 !important;
 }

--- a/app/styles/_notification-window.scss
+++ b/app/styles/_notification-window.scss
@@ -1,3 +1,22 @@
 .right {
     float:right;
 }
+
+.nav-pills > li {
+    float: left; }
+    .nav-pills > li > a {
+      border-radius: 0px;
+      color: #3b4246;
+      background-color: #eeeeef; }
+      .nav-pills > li > a:hover, .nav-pills > li > a:focus {
+        background-color: #eeeeef;
+        border-top: 4px solid #009dd3;
+        padding-top: 6px; }
+    .nav-pills > li + li {
+      margin-left: 2px; }
+    .nav-pills > li.active > a {
+      background-color: #2b3036; }
+      .nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus, .nav-pills > li > .notification-selected {
+        color: #009dd3;
+        border-top: 4px solid #009dd3;
+        padding-top: 6px; }

--- a/app/styles/_notification.scss
+++ b/app/styles/_notification.scss
@@ -3,7 +3,7 @@
     $divider-height: (9px * 2) + 1px;
     $notifications-visible: 7;
 
-    padding: 0;
+    padding: 0 9;
     width: 400px;
     max-height: ($notification-height + $divider-height) * $notifications-visible;
     overflow-y: auto;
@@ -14,9 +14,8 @@
   }
 
   .divider {
-      padding:0;
-      margin:0;
-      background-color:inherit !important;
+      margin-top: 0;
+      margin-bottom: 0;
   }
 }
 

--- a/app/styles/_notification.scss
+++ b/app/styles/_notification.scss
@@ -3,7 +3,7 @@
     $divider-height: (9px * 2) + 1px;
     $notifications-visible: 7;
 
-    padding: 0 9;
+    padding: 0;
     width: 400px;
     max-height: ($notification-height + $divider-height) * $notifications-visible;
     overflow-y: auto;
@@ -20,7 +20,7 @@
 }
 
 .UserNotification {
-    padding: 0px 15px;
+    padding: 5px 15px;
     background-color: $gray-darkest;
     color: $gray-light;
     word-wrap: break-word;

--- a/app/styles/_notification.scss
+++ b/app/styles/_notification.scss
@@ -52,7 +52,7 @@
 
     .created-by {
         margin: 10px 0 0 0;
-        font-weight: 500;
+        font-weight: 400;
         color: $white;
     }
 

--- a/app/styles/_notification.scss
+++ b/app/styles/_notification.scss
@@ -12,6 +12,12 @@
     margin: 5px 15px 15px 0;
     float: right;
   }
+
+  .divider {
+      padding:0;
+      margin:0;
+      background-color:inherit !important;
+  }
 }
 
 .UserNotification {
@@ -77,9 +83,16 @@
 }
 
 .unread {
+    border-left: $blue solid 4px;
+
     .created-by {
         font-weight: 700;
     }
+
+    .created-at {
+        font-weight: 400;
+    }
+
 }
 
 .NotificationBadge {

--- a/app/styles/commons.scss
+++ b/app/styles/commons.scss
@@ -3,6 +3,7 @@
 @import "mixins";
 @import "switches";
 @import "notification";
+@import "notification-window";
 @import "profile-window";
 @import "contacts-window";
 @import "settings-window";


### PR DESCRIPTION
Make sure to pull latest backend branch

This builds upon the other PR https://github.com/aml-development/ozp-react-commons/pull/91 . The changes introduced by this PR are 

- Updated styling and notification click functionality to make an unread notification appear much different than a read notification
- Refactored notification content into a shared class so that the text for notifications is the same in the drop down and in the modal
- Corrected the issue with the folder share not working

To test: Jira ticket #460:
(need to have center running and updated ozp-react-commons to point to this branch)
- Create two new notifications for your user
- Click on the drop down
- Both should have bold titles and a blue bar to the left of the notification to indicate that they are unread
- Click on one of the notifications
- The notification drop down should not close and the notification should no longer have a blue bar and should have a less bold title

To test: Jira ticket # 658
(need to have hud running and updated ozp-react-commons to point to this branch)
- Log on as bigbrother
- Share a folder with wsmith
-  Log on as wsmith
- See notifications
- Choose the Add button
OLD RESULTS - Nothing
EXPECTED RESULTS - it should add the folder to the recipients HUD screen
