### PR TITLE
added class to commons.scss for blue button

### DIFF
--- a/app/styles/commons.scss
+++ b/app/styles/commons.scss
@@ -119,7 +119,7 @@ button.close {
     .popover-subtitle {
         padding-top: 0;
     }
-    
+
     .popover-content,
     .popover-navigation {
         color: $gray-darker;
@@ -127,6 +127,12 @@ button.close {
 
     .popover-navigation {
         padding-bottom: 25px;
+    }
+
+    #end-tour-btn:hover, #end-tour-btn:focus, #end-tour-btn.focus, #end-tour-btn:active, #end-tour-btn.active {
+        color: #ffffff;
+        background-color: #087399;
+        border-color: #087399;
     }
 
     &.bottom > .arrow { border-bottom-color: $blue; }
@@ -166,4 +172,3 @@ button.close {
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
-


### PR DESCRIPTION
In center and HUD tour, hover mouse over 'No thanks' button. Button should turn blue. If tabbed to the button should turn blue. Similar to the 'Start the tour' button. Following ticket #847

Need both https://github.com/aml-development/ozp-center/pull/851/files 
and https://github.com/aml-development/ozp-hud/pull/201/files 
for testing