### PR TITLE
added formatting to popover-header

### DIFF
--- a/app/styles/commons.scss
+++ b/app/styles/commons.scss
@@ -108,6 +108,11 @@ button.close {
         padding: 5px 25px;
     }
 
+    .popover-header {
+      color:#3b4246;
+      font-size:28px;
+    }
+
     .popover-title {
         background: transparent;
         color: $blue-dark;


### PR DESCRIPTION
Added formatting to popover-header. this only effects "Welcome to" in tour on center and HUD.

No changes should be required for HUD or Center tours.