### PR TITLE
feat(phone_ext): Allow users to add a phone extension to listings

### DIFF
--- a/app/js/constants/index.js
+++ b/app/js/constants/index.js
@@ -6,7 +6,7 @@ module.exports = {
     FOCUSABLE_ELEMENTS: 'input, select, textarea',
 
     URL_REGEX: /^(((https|http|ftp|sftp|file):\/)|(\/)){1}(.*)+$/,
-    PHONE_REGEX: /(^\+\d((([\s.-])?\d+)?)+$)|(^(\(\d{3}\)\s?|^\d{3}[\s.-]?)?\d{3}[\s.-]?\d{4}$)/,
+    PHONE_REGEX: /(^\+\d((([\s.-])?\d+)?)+$)|(^(\(\d{3}\)\s?|^\d{3}[\s.-]?)?\d{3}[\s.-]?\d{4})(?:[\-\.\ \\\/]?(?:#|ext\.?|extension|x)[\-\.\ \\\/]?(\d+))?$/,
     EMAIL_REGEX: /^([a-zA-Z0-9_\.\-'])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/,
 
     listingActions: {

--- a/app/js/constants/messages.js
+++ b/app/js/constants/messages.js
@@ -114,7 +114,7 @@ var listingMessages = {
     'help.contacts.organization': 'May contain letters, numbers or symbols and must be 100 characters long or less.',
     'help.contacts.email': 'Must be a valid email address and 100 characters long or less.',
     'help.contacts.securePhone': 'Must be a valid phone number.',
-    'help.contacts.unsecurePhone': 'Must be a valid phone number.',
+    'help.contacts.unsecurePhone': 'Must be a valid phone number. Add extensions with x#### or ext#### after the phone number.',
     'help.screenshots.largeImage': 'Must be a .png, .jpg, or .gif file and must be smaller than 1MB.',
     'help.screenshots.largeImageMarking': markingHelp,
     'help.screenshots.smallImage': 'Must be a .png, .jpg, or .gif file and must be smaller than 1MB.',


### PR DESCRIPTION
JIRA-713

To test:

After pulling the branch, go to Create/Edit (Submit a Listing) page.
Scroll to the bottom of the page and click Add New under the Contacts section.
The Unsecure Phone section will have an updated message telling the user how to add an extension.
Use case examples for the phone validation:
###-####
###-###-####
(###) ###-####
###-###-#### x##
###-###-#### x###
###-###-#### x####
###-###-#### ext###
etc, etc
'extension' will also work.



(A new field in the create/edit form was deemed unncessary for this feature.  The backend for a phone number already supports upto 50 characters as a string.  The only step needed to allow the user to add an extension was to update the JS REGEX validation to allow x/ext/extension + a number.)
