### PR TITLE
fix(notifications): add url handler when opening See More from the no…

### DIFF
--- a/app/js/components/notification/UserNotifications.jsx
+++ b/app/js/components/notification/UserNotifications.jsx
@@ -4,6 +4,7 @@ var React = require('react');
 var Reflux = require('reflux');
 var UserNotification = require('./UserNotification.jsx');
 var ProfileActions = require('../../actions/ProfileActions.js');
+var { CENTER_URL} = require('../../OzoneConfig');
 
 
 var UserNotifications = React.createClass({
@@ -30,6 +31,13 @@ var UserNotifications = React.createClass({
         });
     },
 
+    open: function(){
+        if(window.location.href.indexOf(CENTER_URL) != -1)
+            window.location.href = window.location.href + (window.location.href.indexOf('?') == -1 ? '?' : '&') + 'notifications=true';
+        else
+            this.props.moreNotifications();
+    },
+
     render() {
         var notifications = this.props.notifications;
         if (notifications && notifications.length > 0) {
@@ -39,7 +47,7 @@ var UserNotifications = React.createClass({
                 <ul style={{'zIndex': '10000000'}} className="dropdown-menu UserNotifications">
                     { this._renderNotifications(this.props.func) }
                     <li>
-                      <button className="btn btn-primary btn-sm" onClick={() => this.props.moreNotifications()}>See more</button>
+                      <button className="btn btn-primary btn-sm" onClick={this.open}>See more</button>
                     </li>
                 </ul>
             );


### PR DESCRIPTION
…tifications drop down to fix Go to Listing Management functionality. Handled differently between Center and HUD

A non-PR, PR.  Another proof of concept.  I'm hoping there's a better way, but this fixes the issue presented in https://github.com/aml-development/ozp-center/pull/893#issuecomment-342611000 when opening the Go to Listing Manage link in Notifications.


