### PR TITLE
Change metrics URL to use IP/Metrics

### DIFF
--- a/app/OzoneConfig.js
+++ b/app/OzoneConfig.js
@@ -25,7 +25,7 @@ window.OzoneConfig = {
     "METRICS_URL": '/* @echo METRICS_URL */',
     // @endif
     // @ifndef METRICS_URL
-    "METRICS_URL": "http://172.16.98.67/metrics-3.0/",
+    "METRICS_URL": "http://172.16.98.67/metrics/",
     // @endif
     // @ifdef METRICS_HUD_SITE_ID
     "METRICS_HUD_SITE_ID": '/* @echo METRICS_HUD_SITE_ID */',


### PR DESCRIPTION
Changing URL to use http://xxx.xxx.xxx.xxx/metrtics/
instead of xxx.xxx.xxx.xxx/metrtics-3.0/ to expedite
updating Piwik in the future.

AMLNG-826

**Description**
Rename UDEV Web Analyitics current version to "Metrics"

**Acceptance Criteria**
• The default metrics URL will be changed to http://xxx.xxx.xxx.xxx/metrtics/

**How to test code**
With center running, go to the menu in the top right and select Metrics. 
This should send you to http://172.16.98.67/metrics/