### PR TITLE
fix(notifications): error checking addition for old notifications whe…

### DIFF
--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -7,10 +7,14 @@ var { CENTER_URL } = require('../../OzoneConfig');
 var renderer = new marked.Renderer();
 
 function getLink(listing, tabName) {
-    var id = listing.id;
+    if(listing && listing.id){
+        var id = listing.id;
 
-    var url = `${CENTER_URL}/#/home/?listing=${encodeURIComponent(id)}&action=view&tab=${encodeURIComponent(tabName)}`;
-    return url;
+        var url = `${CENTER_URL}/#/home/?listing=${encodeURIComponent(id)}&action=view&tab=${encodeURIComponent(tabName)}`;
+        return url;
+    } else {
+        return `${CENTER_URL}`;
+    }
 };
 
 var NotificationContent = React.createClass({
@@ -38,11 +42,11 @@ var NotificationContent = React.createClass({
                     </div>
                     </div>
                 }
-                {notification.notificationSubtype === 'listing_review' && <p class="small right"><a href={getLink(notification.listing, 'reviews')}>View reviews</a></p>}
+                {notification.notificationSubtype === 'listing_review' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'reviews')}>View reviews</a></p>}
                 {notification.notificationSubtype === 'pending_deletion_cancellation' && <p class="small right"><a href={`${CENTER_URL}/#/user-management/my-listings`}>View my listings</a></p>}
-                {notification.notificationSubtype === 'listing_new' && <p class="small right"><a href={getLink(notification.listing, 'administration')}>View submission</a></p>}
+                {notification.notificationSubtype === 'listing_new' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'administration')}>View submission</a></p>}
                 {notification.notificationSubtype === 'review_request' && <p class="small right"><a href={`${CENTER_URL}/#/user-management/recent-activity`}>Go to Listing Management</a></p>}
-                {notification.notificationType === 'subscription' && <p class="small right"><a href={getLink(notification.listing, 'overview')}>View listing</a></p>}
+                {notification.notificationType === 'subscription' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'overview')}>View listing</a></p>}
             </div>
         )
     }


### PR DESCRIPTION
…n a listing wasn't attached to the notification

AMLNG-832

TBH, there's not good way to test this locally.  This was not producible in dev.  The guess is that we had some subscription notifications created in production prior to adding the feature of linking to the Listing, so the Listing id wasn't stored in those listings.

Pull the code, and make sure there's no side-effects and that links created in notifications (Subscription, Listing Submitted, Listing Rated) all work as expected.

This fix adds error checking to:
- Not create a link if listing is undefined
- A secondary check in getLink to return a link to Center if listing is undefined.