### PR TITLE
fix(subscriptions): category subscriptions in profile

### DIFF
--- a/app/js/components/profile/CategorySubscriptions.jsx
+++ b/app/js/components/profile/CategorySubscriptions.jsx
@@ -17,16 +17,12 @@ var Category = React.createClass({
 
     render: function() {
         var {category} = this.props;
-        if (category.entity_description === "OBJECT NOT FOUND"){
-            return null;
-        }else{
-            return (
-                <li className="select2-search-choice">
-                    <div>{category.entity_description}</div>
-                    <a className="select2-search-choice-close" tabIndex="-1" onClick={() => this.unsubscribeFromCategory()}></a>
-                </li>
-            )
-        }
+        return (
+            <li className="select2-search-choice">
+                <div>{category.entity_description}</div>
+                <a className="select2-search-choice-close" tabIndex="-1" onClick={() => this.unsubscribeFromCategory()}></a>
+            </li>
+        )
     }
 
 });

--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -12,6 +12,10 @@ var CategorySubscriptions = require('./CategorySubscriptions.jsx');
 var TagSubscriptions = require('./TagSubscriptions.jsx');
 var { API_URL } = require('../../OzoneConfig');
 var DEFAULT_ICON = 1  // TODO: Replace with something other than Android icon
+var TagSubscriptionActions = require('../../actions/TagSubscriptionActions');
+var TagSubscriptionStore = require('../../stores/TagSubscriptionStore');
+var CategorySubscriptionActions = require('../../actions/CategorySubscriptionActions');
+var CategorySubscriptionStore = require('../../stores/CategorySubscriptionStore');
 
 var ListingRow = React.createClass({
 
@@ -182,7 +186,7 @@ var ProfileInfo = React.createClass({
 });
 
 var ProfileWindow = React.createClass({
-    mixins: [Navigation],
+    mixins: [Reflux.connect(CategorySubscriptionStore, "categorySubscriptionStore"), Reflux.connect(TagSubscriptionStore, "tagSubscriptionStore"), Navigation],
 
     propTypes: {
         profileId: React.PropTypes.oneOfType([
@@ -209,6 +213,11 @@ var ProfileWindow = React.createClass({
                     listingLinkEl={this.props.listingLinkEl} />
             </Modal>
         );
+    },
+
+    componentDidMount: function () {
+        TagSubscriptionActions.fetchSubscriptions();
+        CategorySubscriptionActions.fetchSubscriptions();
     },
 
     close: function() {

--- a/app/js/stores/CategorySubscriptionStore.js
+++ b/app/js/stores/CategorySubscriptionStore.js
@@ -55,6 +55,13 @@ var CategorySubscriptionStore = Reflux.createStore({
     },
 
     getDefaultData: function() {
+        var validCategories = []
+        this.categorySubscriptions.forEach(function(element) {
+            if (element.entity_description !== "OBJECT NOT FOUND"){
+                validCategories.push(element);
+            }
+        });
+        this.categorySubscriptions = validCategories;
         return this.categorySubscriptions;
     }
 });


### PR DESCRIPTION
Fix issue where deleting a category leaves "OBJECT NOT FOUND" result in
profile.
Removes invalid objects at store level.
Add call to store from profile window to fix issue where deleting
category and opening profile displays category.

Closes AMLNG-784

**Description** / **Acceptance Criteria** / **How to test code**
Create a new empty Category.
Subscribe to the Category.
View user profile to see new category.
Delete new Category.
View user profile to see error.