### PR TITLE
feat(profile): add organizations within profile modal

### DIFF
--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -154,13 +154,18 @@ var ProfileInfo = React.createClass({
             });
 
         if (profile) {
+            var orgs = this.state.profile.organizations.map(function (org, i){
+                return <li key={i}>{org}</li>;
+            });
 
             return (
                 <section>
                     <div className="col-md-4 col-sm-6">
                         <i className="icon-head-60-grayLighter" />
                         <h2>{profile.displayName}</h2>
-                        <p><b>{profile.username}</b><br />{profile.email}</p>
+                        <p><b>{profile.username}</b><br/>
+                        {orgs}<br/>
+                        {profile.email}</p>
                     </div>
                     <div className="col-md-8">
                         <div className="row col-md-12 col-sm-6 owned-listings">

--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -155,7 +155,7 @@ var ProfileInfo = React.createClass({
 
         if (profile) {
             var orgs = this.state.profile.organizations.map(function (org, i){
-                return <li key={i}>{org}</li>;
+                return <span className="company" key={i}>{org}</span>;
             });
 
             return (
@@ -163,7 +163,7 @@ var ProfileInfo = React.createClass({
                     <div className="col-md-4 col-sm-6">
                         <i className="icon-head-60-grayLighter" />
                         <h2>{profile.displayName}</h2>
-                        <p><b>{profile.username}</b><br/>
+                        <p><b>{profile.username}</b>
                         {orgs}<br/>
                         {profile.email}</p>
                     </div>

--- a/app/js/components/profile/__tests__/ProfileWindow-test.js
+++ b/app/js/components/profile/__tests__/ProfileWindow-test.js
@@ -82,6 +82,7 @@ describe('ProfileWindow', function() {
             profile: {
                 displayName: 'Test User 1',
                 username: 'testUser1',
+                organizations: ['testOrg'],
                 email: 'testUser1@example.com'
             },
             ownedListings: [{
@@ -202,6 +203,7 @@ describe('ProfileWindow', function() {
             profile: {
                 displayName: 'Test User 1',
                 username: 'testUser1',
+                organizations: ['testOrg'],
                 email: 'testUser1@example.com'
             },
             ownedListings: [{

--- a/app/styles/_profile-window.scss
+++ b/app/styles/_profile-window.scss
@@ -11,6 +11,17 @@
        height: 0;
        clear: both;
     }
+
+    .company {
+        background: $gray-lightest;
+        padding: 2px 10px;
+        border-radius: 10px;
+        display: inline-block;
+        position: relative;
+        font-size: 12px;
+        left: 10px;
+        white-space: nowrap;
+    }
 }
 
 .owned-listings {


### PR DESCRIPTION
As a user, I want my organization to appear under the username in the Profile Modal so that I can confirm correct information.

Acceptance Criteria:
user organization will appear under the username and above email address on Profile Modal