### PR TITLE
feat(notifications, quickview, profiles): Additional load indicators

### DIFF
--- a/app/js/components/LoadIndicator.jsx
+++ b/app/js/components/LoadIndicator.jsx
@@ -1,0 +1,35 @@
+'use strict';
+
+var React = require('react');
+
+var LoadIndicator = React.createClass({
+    render() {
+        var title = this.props.showError ? null : this.props.title;
+        var loadIcon = this.props.showError ?
+            <span className="icon-exclamation-36 loader"></span> :
+            <span className="icon-loader-36 loader loader-animate"></span>;
+        var displayMessage = this.props.showError ?
+            this.props.errorMessage : this.props.message;
+
+        return (
+            <section className="loader">
+                { title &&
+                    <h5 className="loader-title">{ title }</h5>
+                }
+                { loadIcon }
+                { displayMessage &&
+                    <h5 className="loader-message">{ displayMessage }</h5>
+                }
+            </section>
+        );
+    },
+
+    shouldComponentUpdate(newProps) {
+        return newProps.title !== this.props.title
+            || newProps.message !== this.props.message
+            || newProps.showError !== this.props.showError
+            || newProps.errorMessage !== this.props.errorMessage;
+    }
+});
+
+module.exports = LoadIndicator;

--- a/app/js/components/profile/ProfileWindow.jsx
+++ b/app/js/components/profile/ProfileWindow.jsx
@@ -10,6 +10,7 @@ var CurrentProfileStore = require('../../stores/CurrentProfileStore');
 var ProfileActions = require('../../actions/ProfileActions');
 var CategorySubscriptions = require('./CategorySubscriptions.jsx');
 var TagSubscriptions = require('./TagSubscriptions.jsx');
+var LoadIndicator = require('../LoadIndicator.jsx');
 var { API_URL } = require('../../OzoneConfig');
 var DEFAULT_ICON = 1  // TODO: Replace with something other than Android icon
 var TagSubscriptionActions = require('../../actions/TagSubscriptionActions');
@@ -53,7 +54,7 @@ var ProfileInfo = React.createClass({
     },
 
     getInitialState: function() {
-        return {profile: null, ownedListings: []};
+        return {profile: null, ownedListings: [], loading: true, loadingError: false};
     },
 
     componentWillMount: function() {
@@ -168,9 +169,10 @@ var ProfileInfo = React.createClass({
                         </div>
                         <div className="row col-md-12 col-sm-6 owned-listings">
                             <h4>{profile.displayName}'s Listings</h4>
-                            <ul>{listings}</ul>
-                            { listings.length < 1 &&
-                                <p>You have not created any listings yet. To start, submit a listing from the global menu.</p>
+                            {this.state.loading ?
+                                <LoadIndicator/> :
+                                 listings.length < 1 ?
+                                    <p>You have not created any listings yet. To start, submit a listing from the global menu.</p> : <ul>{listings}</ul>
                             }
                         </div>
                     </div>

--- a/app/js/components/profile/__tests__/ProfileWindow-test.js
+++ b/app/js/components/profile/__tests__/ProfileWindow-test.js
@@ -79,6 +79,7 @@ describe('ProfileWindow', function() {
         );
 
         var storeData = {
+            loading: false,
             profile: {
                 displayName: 'Test User 1',
                 username: 'testUser1',
@@ -199,6 +200,7 @@ describe('ProfileWindow', function() {
         );
 
         var storeData = {
+            loading: false,
             profile: {
                 displayName: 'Test User 1',
                 username: 'testUser1',

--- a/app/js/stores/CurrentProfileStore.js
+++ b/app/js/stores/CurrentProfileStore.js
@@ -15,11 +15,13 @@ var CurrentProfileStore = Reflux.createStore({
     ownedListings: [],
     profile: null,
     isSelf: false,
+    loading: true,
+    loadingError: false,
 
     listenables: ProfileActions,
 
     getDefaultData: function() {
-        return _.pick(this, 'profile', 'ownedListings', 'isSelf');
+        return _.pick(this, 'profile', 'ownedListings', 'isSelf',       'loading', 'loadingError');
     },
 
     doTrigger: function() {
@@ -30,6 +32,8 @@ var CurrentProfileStore = Reflux.createStore({
         var me = this;
         ProfileApi.getOwnedListings(profileId).then(function(listings) {
             me.ownedListings = listings;
+            me.loading = false;
+            me.loadingError = false;
             me.doTrigger();
         });
     },


### PR DESCRIPTION
Add load indicators to various areas of the application, specifically: loading user profiles (listings), tabs in the listing quickview (administration, reviews, notifications), center settings (notifications)

closes AMLNG-808, AMLNG-809, relates to AMLNG-838

**Description**
When loading the user profile, listing quickview, and loading notifications in center settings, update loading process to implement indicator used when Center page first loads.

**Acceptance Criteria**
use site data loading indicator image as placeholder until result set is displayed
same layout as Center page

**How to test code**
Pull additional_load_indicators from ozp-react-commons
Pull additional_load_indicators from ozp-center
Ensure that ozp-center is built with the additional_load_indicators branch of ozp-react-commons