### PR TITLE
AMLNG-700: Undo delete folder

### DIFF
--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -45,11 +45,10 @@ var NotificationContent = React.createClass({
                 { notification.notificationType === "restore_bookmark" &&
                     <div>
                     <p className="message small">{notification.peer.folderName?'The folder '+notification.peer.folderName :'A folder'} was recently deleted.</p>
-                    <p className="message small">Click the button to restore it</p>
                     <div>
                         <button className="btn btn-success btn-sm" onClick={() => {
                             SelfActions.addBookmarkFolder(notification);
-                        }}>Restore folder {notification.peer.folderName}</button>
+                        }}>Restore folder: {notification.peer.folderName}</button>
                     </div>
                     </div>
                 }

--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -28,7 +28,7 @@ var NotificationContent = React.createClass({
           };
         return (
             <div>
-                { notification.notificationType !== "peer_bookmark" &&
+                { notification.notificationType !== "peer_bookmark" && notification.notificationType !== "restore_bookmark" &&
                 <span className="message small" dangerouslySetInnerHTML={createNotificationText()}></span>
                 }
                 { notification.notificationType === "peer_bookmark" &&
@@ -39,6 +39,17 @@ var NotificationContent = React.createClass({
                         <button className="btn btn-success btn-sm" onClick={() => {
                             SelfActions.addBookmarkFolder(notification);
                         }}>Add folder {notification.peer.folderName}</button>
+                    </div>
+                    </div>
+                }
+                { notification.notificationType === "restore_bookmark" &&
+                    <div>
+                    <p className="message small">{notification.peer.folderName?'The folder '+notification.peer.folderName :'A folder'} was recently deleted.</p>
+                    <p className="message small">Click the button to restore it</p>
+                    <div>
+                        <button className="btn btn-success btn-sm" onClick={() => {
+                            SelfActions.addBookmarkFolder(notification);
+                        }}>Restore folder {notification.peer.folderName}</button>
                     </div>
                     </div>
                 }


### PR DESCRIPTION
AMLNG-700: Bookmark Folder / un-delete button

Acceptance Criteria:
- ability to restore deleted folder
- undelete button with instructions
- un-delete warning/popup
- notification with link to restore folder

To test:
The `undo_delete_folder` branches are needed from ozp-hud/ozp-center/ozp-backend/ozp-react-commons.

- Log into HUD with any user.
  - If the user does not already have bookmarks & bookmark folders, find listings to bookmark, and create some folders.
- Choose the Delete option from any Folder menu.
Results:
Banner is displayed alerting the user the folder was deleted.
The **undo** link will restore the folder
The banner will go away after 10 seconds if not interacted with
The user can click the X in the banner to close it.

- Refresh the page
Results:
A new notification will be active
Notification will tell the user a folder was recently deleted
The Notification will have a button that allows the user to restore the folder

- Go to Center, Log in as an admin user, if not already.
- Go to Center Settings -> Notifications
Results:
Notification about restoring a deleted folder will NOT be visible in Active Notifications.

