### PR TITLE
fix(profile): fix bugs in HUD profile window

### DIFF
--- a/app/js/components/LoadIndicator.jsx
+++ b/app/js/components/LoadIndicator.jsx
@@ -6,8 +6,8 @@ var LoadIndicator = React.createClass({
     render() {
         var title = this.props.showError ? null : this.props.title;
         var loadIcon = this.props.showError ?
-            <span className="icon-exclamation-36 loader"></span> :
-            <span className="icon-loader-36 loader loader-animate"></span>;
+            <span className="icon-exclamation-36"></span> :
+            <span className="icon-loader-36 loader-animate"></span>;
         var displayMessage = this.props.showError ?
             this.props.errorMessage : this.props.message;
 
@@ -16,7 +16,9 @@ var LoadIndicator = React.createClass({
                 { title &&
                     <h5 className="loader-title">{ title }</h5>
                 }
-                { loadIcon }
+                <div className="loader-icon loader">
+                    { loadIcon }
+                </div>
                 { displayMessage &&
                     <h5 className="loader-message">{ displayMessage }</h5>
                 }

--- a/app/js/stores/CurrentProfileStore.js
+++ b/app/js/stores/CurrentProfileStore.js
@@ -21,7 +21,7 @@ var CurrentProfileStore = Reflux.createStore({
     listenables: ProfileActions,
 
     getDefaultData: function() {
-        return _.pick(this, 'profile', 'ownedListings', 'isSelf',       'loading', 'loadingError');
+        return _.pick(this, 'profile', 'ownedListings', 'isSelf', 'loading', 'loadingError');
     },
 
     doTrigger: function() {

--- a/app/styles/commons.scss
+++ b/app/styles/commons.scss
@@ -179,3 +179,35 @@ button.close {
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
+
+.loader {
+    margin: 0 auto;
+    display: block;
+    text-align: center;
+}
+
+.loader-icon {
+    width: 50px;
+}
+
+.loader-animate {
+    -animation: spin .9s infinite linear;
+    -ms-animation: spin2 .9s infinite linear;
+    -moz-animation: spin2 .9s infinite linear;
+    -webkit-animation: spin2 .9s infinite linear;
+}
+
+@-webkit-keyframes spin2 {
+    from { -webkit-transform: rotate(0deg);}
+    to { -webkit-transform: rotate(360deg);}
+}
+
+@keyframes spin {
+    from { transform: scale(1) rotate(0deg);}
+    to { transform: scale(1) rotate(360deg);}
+}
+
+@keyframes spin2 {
+    from { transform: scale(1) rotate(0deg);}
+    to { transform: scale(1) rotate(360deg);}
+}


### PR DESCRIPTION
**Description**

Fix bugs in the profile window on the HUD page.  These bugs are not present when opening the profile on the Center page.

**Acceptance Criteria**

Open the profile window in HUD:
1) Ensure that when loading listings, the spinner icon is centered and animates
2) Ensure that all profile information, including settings and subscriptions, are visible in the window.

Note that you can compare the HUD profile to the correctly working Center profile.  If you spot any differences, then there is a bug/issue.

**How to Test Code**

Pull `fix_profile` from `ozp-center`
Pull `fix_profile` from `ozp-hud`
Pull `fix_profile` from `ozp-react-commons`

Update `package.json` in HUD and Center to point to this branch or your local `ozp-react-commons` repo