### PR TITLE
fix(dependencies): Upgrade Jquery Dependency

### DIFF
--- a/app/js/stores/SelfStore.js
+++ b/app/js/stores/SelfStore.js
@@ -41,13 +41,10 @@ var SelfStore = Reflux.createStore({
         var me = this,
             trigger = me.doTrigger.bind(me);
 
-        promise.then(function(profile) {
+        promise.done(function(profile) {
             me.currentUserError = false;
             me.currentUser = Object.assign({}, profile, profileFunctions);
-        }, function() {
-            me.currentUserError = OzpError.apply(null, arguments);
-            me.currentUser = null;
-        }).then(trigger, trigger);
+        }).done(trigger);
     },
 
     onFetchSelf: function () {

--- a/app/js/stores/__tests__/CurrentProfileStore-test.js
+++ b/app/js/stores/__tests__/CurrentProfileStore-test.js
@@ -50,17 +50,18 @@ describe('CurrentProfileStore', function() {
             expect(getOwnedListingsSpy.calledWith()).to.be.true();
 
             apiDeferred.resolve(ownedListings);
+            setTimeout(function() {
+                expect(storeTriggerSpy.calledOnce).to.be.true();
+                expect(storeTriggerSpy.calledWithMatch({
+                    profile: null,
+                    ownedListings: ownedListings
+                })).to.be.true();
 
-            expect(storeTriggerSpy.calledOnce).to.be.true();
-            expect(storeTriggerSpy.calledWithMatch({
-                profile: null,
-                ownedListings: ownedListings
-            })).to.be.true();
+                //remove action listenens so later tests don't get messed up
+                CurrentProfileStore.stopListeningToAll();
 
-            //remove action listenens so later tests don't get messed up
-            CurrentProfileStore.stopListeningToAll();
-
-            done();
+                done();
+            });
         });
 
         ProfileActions.fetchOwnedListings();
@@ -92,17 +93,18 @@ describe('CurrentProfileStore', function() {
             expect(getProfileSpy.calledWith()).to.be.true();
 
             apiDeferred.resolve(profile);
+            setTimeout(function() {
+                expect(storeTriggerSpy.calledOnce).to.be.true();
+                expect(storeTriggerSpy.calledWithMatch({
+                    profile: profile,
+                    ownedListings: []
+                })).to.be.true();
 
-            expect(storeTriggerSpy.calledOnce).to.be.true();
-            expect(storeTriggerSpy.calledWithMatch({
-                profile: profile,
-                ownedListings: []
-            })).to.be.true();
+                //remove action listenens so later tests don't get messed up
+                CurrentProfileStore.stopListeningToAll();
 
-            //remove action listenens so later tests don't get messed up
-            CurrentProfileStore.stopListeningToAll();
-
-            done();
+                done();
+            });
         });
 
         ProfileActions.fetchProfile();
@@ -147,12 +149,13 @@ describe('CurrentProfileStore', function() {
             expect(getProfileSpy.calledWith()).to.be.true();
 
             getProfileDeferred.resolve(profile);
-
-            expect(storeTriggerSpy.calledOnce).to.be.true();
-            expect(storeTriggerSpy.calledWithMatch({
-                profile: profile,
-                ownedListings: []
-            })).to.be.true();
+            setTimeout(function() {
+                expect(storeTriggerSpy.calledOnce).to.be.true();
+                expect(storeTriggerSpy.calledWithMatch({
+                    profile: profile,
+                    ownedListings: []
+                })).to.be.true();
+            });
 
             ProfileActions.fetchOwnedListings.listen(function() {
                 expect(getOwnedListingsSpy.calledOnce).to.be.true();
@@ -161,13 +164,13 @@ describe('CurrentProfileStore', function() {
                 expect(getProfileSpy.calledWith()).to.be.true();
 
                 getOwnedListingsDeferred.resolve(ownedListings);
-
-                expect(storeTriggerSpy.calledTwice).to.be.true();
-                expect(storeTriggerSpy.calledWithMatch({
-                    profile: profile, //the important part here is that this isn't null
-                    ownedListings: ownedListings
-                })).to.be.true();
-
+                setTimeout(function() {
+                    expect(storeTriggerSpy.calledTwice).to.be.true();
+                    expect(storeTriggerSpy.calledWithMatch({
+                        profile: profile, //the important part here is that this isn't null
+                        ownedListings: ownedListings
+                    })).to.be.true();
+                });
                 //remove action listenens so later tests don't get messed up
                 CurrentProfileStore.stopListeningToAll();
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bootstrap-sass": "git://github.com/ozone-development/bootstrap-sass#master",
     "es5-shim": "^4.0.6",
     "humps": "git://github.com/domchristie/humps.git",
-    "jquery": "^2.1.1",
+    "jquery": "~3.2.0",
     "lodash-amd": "2.4.1",
     "marked": "^0.3.5",
     "object-assign": "1.0.0",


### PR DESCRIPTION
Upgrade Jquery dependency from 2.1.1 to 3.2.x.
Modifies tests to support updated Jquery function definitions.

Closes #AMLNG-919

Updates Jquery dependency to remove warning messages in git. 

**How To Test**
Add this branch to your package.json file and install it for center and HUD.
Test full site functionality.