### PR TITLE
fix(notifications): pend for delete notifications

### DIFF
--- a/app/js/components/notification/NotificationContent.jsx
+++ b/app/js/components/notification/NotificationContent.jsx
@@ -53,7 +53,7 @@ var NotificationContent = React.createClass({
                     </div>
                 }
                 {notification.notificationSubtype === 'listing_review' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'reviews')}>View reviews</a></p>}
-                {notification.notificationSubtype === 'pending_deletion_cancellation' && <p class="small right"><a href={`${CENTER_URL}/#/user-management/my-listings`}>View my listings</a></p>}
+                {(notification.notificationSubtype === 'pending_deletion_to_steward' || notification.notificationSubtype === 'pending_deletion_to_owner') && <p class="small right"><a href={getLink(notification.listing, 'administration')}>Click to view</a></p>}
                 {notification.notificationSubtype === 'listing_new' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'administration')}>View submission</a></p>}
                 {notification.notificationSubtype === 'review_request' && <p class="small right"><a href={`${CENTER_URL}/#/user-management/recent-activity`}>Go to Listing Management</a></p>}
                 {notification.notificationType === 'subscription' && notification.listing && <p class="small right"><a href={getLink(notification.listing, 'overview')}>View listing</a></p>}


### PR DESCRIPTION
AMLOS-490

**Description**     
"Pend for deletion" request should launch notification to org steward.

**Acceptance Criteria**   
Steps to verify:
Pre-req- set jones as owner of Chart Course App
Log on as jones 
Edit Chart Course and set to pend for deletion 
Log on as org steward ( julia) 
RESULTS - Should have a notification that mentions the pending for deletion request.
 
**How to test code**    
Pull this branch. Pull  pending_deletion_notification_updates from react commons.
As jones, pend a listing for delete. Bigbrother and julia should receive notification.
As jones, cancel the request. Bigbrother and julia should receive notification.
As jones, pend a listing for delete.
As bigbrother and julia, return the request. Jones should receive a notification
As jones, pend a listing for delete.
As bigbrother and julia, approve the request. Jones, bigbrother, and julia should receive a notification that the listing was deleted.
