### PR TITLE
feat(notifications): correct the reading for new notifications

### DIFF
--- a/app/js/components/notification/UserNotificationDropdown.jsx
+++ b/app/js/components/notification/UserNotificationDropdown.jsx
@@ -62,8 +62,8 @@ var UserNotificationDropdown = React.createClass({
             <li data-toggle="tooltip" data-placement="bottom" data-original-title={tooltip} className={notificationButtonClasses} id="notification-dropdown" onClick = {acknowledgeNotifications}>
                 <a href="#" data-toggle="dropdown" id="tourstop-notifications">
                     <i className={bellClassNames}></i>
-                    <span className="hidden-span"> notifications, {(this.state.notifications) ? this.state.notifications.length : 0} unread notifications</span>
-                    {hasUnacknowledgedNotifications && <span className="NotificationBadge" data-badge={unacknowledgedNotifications.length}></span>} 
+                    <span className="hidden-span"> notifications, You have {(this.state.notifications) ? unacknowledgedNotifications.length : 0} new notifications</span>
+                    {hasUnacknowledgedNotifications && <span className="NotificationBadge" data-badge={unacknowledgedNotifications.length}></span>}
                 </a>
                 {
                     hasNotifications &&


### PR DESCRIPTION
Adds reading for new notifications in navbar for users using 508 readout text-to-speech software.

Closes #AMLOS-390

**Acceptance Criteria**
Jaws should read the number in the red circle next to the notification icon in the nav bar.

**how to test**
STR-
Pre-req - Set it up where you have 1 unacknowledged notification. Should display a 1 on the notification bell
Log in to Jaws on top of Apps mall
Tab through to the notifications. 
RESULTS - JAWS reads to user "You have 1 new notification"