### PR TITLE
fix(modal): Close modal on back button press

### DIFF
--- a/app/js/components/Modal.jsx
+++ b/app/js/components/Modal.jsx
@@ -36,6 +36,10 @@ var BootstrapModal = React.createClass({
                 show: true
             });
     },
+    
+    componentWillUnmount: function(){
+        this.close();
+    },
 
     close: function () {
         $(this.getDOMNode()).modal('hide');


### PR DESCRIPTION
When the browsers back button is pressed, this returns the root's style
class back to normal.

Closes #AMLOS-650